### PR TITLE
Typo in 'Avonddiensten'

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
 									</span>
 									<div class="feature-copy">
 										<h3>Avonddiensten</h3>
-										<p>Ik werk ook heel graag in de avonden, in het weekend en op tijdens feestdagen.</p>
+										<p>Ik werk ook heel graag in de avonden, in het weekend en tijdens feestdagen.</p>
 									</div>
 								</div>
 


### PR DESCRIPTION
'[...] en op tijdens feestdagen.' changed to '[...] en tijdens feestdagen.'